### PR TITLE
Added support for Personal accounts

### DIFF
--- a/lib/idid/configuration.rb
+++ b/lib/idid/configuration.rb
@@ -14,8 +14,10 @@ module Idid
       :location => '/usr/bin/exim'
     }
 
-    # Public: Name of the project to post to (e.g. project.idonethis.com)
-    attr_accessor :project
+    # Public: Account type for this user
+    attr_accessor :account_type
+    # Public: Name of the team to post to
+    attr_accessor :team
     # Public: Email address String to use when sending mail.
     attr_accessor :email
     # Public: Email delivery configuration
@@ -24,30 +26,54 @@ module Idid
     # Public: configuration to use with iDoneThis
     #
     # options - Hash with configuration options
-    #           project    - Name of the project to post to (e.g.
-    #                        project.idonethis.com)
     #           email      - Email address to use when sending mail.
     #           delivery   - Email delivery configuration Hash:
     #                        method  - Symbol (:smtp|:sendmail|:exim)
     #                        options - Configuration Hash for the
     #                        delivery method (see:
     #                        https://github.com/mikel/mail).
+    #           team       - Name of the team to post to (optional)
     #
     # Returns a new Idid::Configuration instance
     def initialize(options = {})
       options = read_config.merge options if read_config
-      raise ArgumentError.new "Provide a project to use." unless options['project']
+      raise ArgumentError.new "Provide an account type." unless options['account_type']
+      raise ArgumentError.new "Provide a team to use." if options['account_type'] == 'team' && options['team'].nil?
       raise ArgumentError.new "Provide an email address." unless options['email']
       raise ArgumentError.new "Provide a delivery method." unless options['delivery']
 
-      @project = options['project']
+      @account_type = options['account_type']
+      @team = options['team']
       @email = options['email']
       @delivery = options['delivery']
     end
 
+    # Public: The email address of IDoneThis to send your updates to. This
+    # depends on whether you have a personal or a team account.
+    #
+    # Returns the String with the right email address to use
+    def idonethis_email
+      personal_account? ? "today@idonethis.com" : "#{team}@team.idonethis.com"
+    end
+
+    # Public: Determines if current configuration belongs to a personal account
+    #
+    # Returns boolean
+    def personal_account?
+      account_type == 'personal'
+    end
+
+    # Public: Determines if current configuration belongs to a team account
+    #
+    # Returns boolean
+    def team_account?
+      account_type == 'team'
+    end
+
     def write
       config = {
-        'project' => project,
+        'account_type' => account_type,
+        'team' => team,
         'email'   => email,
         'delivery' => delivery
       }

--- a/lib/idid/delivery.rb
+++ b/lib/idid/delivery.rb
@@ -24,7 +24,7 @@ module Idid
 
       Mail.deliver do
         from    config.email
-        to      "#{config.project}@team.idonethis.com"
+        to      config.idonethis_email
         subject "I did this"
         body    message
       end

--- a/lib/idid/interactive.rb
+++ b/lib/idid/interactive.rb
@@ -6,9 +6,17 @@ module Idid
         status "Please take a moment to create a new configuration.."
         config = user_config
         config['delivery'] ||= {}
-        user_config_from_key 'project', "What is the name of your iDoneThis project (look at the url: <project>.idonethis.com)", nil, config
-        user_config_from_key 'email', "What is your associated email address for this iDoneThis project?", nil, config
-        user_config_from_key 'method', "How do you want to send emails to iDoneThis? (smtp, sendmail, exim)", 'smtp', config['delivery']
+
+        user_config_from_key 'account_type', "What kind of iDoneThis account do you have? (personal|team)", 'personal', config
+
+        if config["account_type"] == 'team'
+          user_config_from_key 'team', "What is the name of your iDoneThis team? (check the URL <team>.idonethis.com).", nil, config
+        else
+          config["team"] = nil
+        end
+
+        user_config_from_key 'email', "What is your associated email address for this iDoneThis account?", nil, config
+        user_config_from_key 'method', "How do you want to send emails to iDoneThis? (smtp|sendmail|exim)", 'smtp', config['delivery']
 
         case config['delivery']['method']
         when 'smtp'

--- a/spec/idid/configuration_spec.rb
+++ b/spec/idid/configuration_spec.rb
@@ -1,32 +1,77 @@
 require 'spec_helper'
 
 describe Idid::Configuration do
-  subject { Idid::Configuration.new('project' => project, 'email' => email, 'delivery' => delivery) }
-  let(:email) { 'foo@example.com' }
-  let(:project) { 'foobar' }
-  let(:delivery) { {:method => :sendmail} }
+  subject { configuration }
 
-  its('project') { should eq project }
-  its('email')   { should eq email   }
+  let(:configuration) { Idid::Configuration.new('team' => team, 'email' => email, 'delivery' => delivery, 'account_type' => account_type) }
+  let(:email) { 'foo@example.com' }
+  let(:team) { 'foobar' }
+  let(:delivery) { {:method => :sendmail} }
+  let(:account_type) { 'team' }
+
+  its('team') { should eq team }
+  its('email') { should eq email }
+  its('account_type') { should eq account_type }
 
   context "when any of the options are missing" do
     before do
       Idid::Configuration.any_instance.stub(:read_config) { nil }
     end
+    let(:account_type) { 'personal' }
+
+    it 'raises ArgumentError if no team option is passed while on a team account' do
+      expect { Idid::Configuration.new('email' => email, 'delivery' => delivery, 'account_type' => 'team') }.
+        to raise_error(ArgumentError, /team/)
+    end
+
+    it 'doesnt raises ArgumentError if no team option is passed while on a personal account' do
+      expect { Idid::Configuration.new('email' => email, 'delivery' => delivery, 'account_type' => 'personal') }.
+        to_not raise_error
+    end
 
     it 'raises ArgumentError if no email option is passed' do
-      expect { Idid::Configuration.new('project' => project, 'delivery' => delivery) }.
+      expect { Idid::Configuration.new('team' => team, 'delivery' => delivery, 'account_type' => account_type) }.
         to raise_error(ArgumentError, /email/)
     end
 
-    it 'raises ArgumentError if no project option is passed' do
-      expect { Idid::Configuration.new('email' => email, 'delivery' => delivery) }.
-        to raise_error(ArgumentError, /project/)
-    end
-
     it 'raises ArgumentError if no delivery option is passed' do
-      expect { Idid::Configuration.new('email' => email, 'project' => project) }.
+      expect { Idid::Configuration.new('email' => email, 'team' => team, 'account_type' => account_type) }.
         to raise_error(ArgumentError, /delivery/)
     end
+
+    it 'raises ArgumentError if no account type is passed' do
+      expect { Idid::Configuration.new('email' => email, 'team' => team, 'delivery' => delivery) }.
+        to raise_error(ArgumentError, /account type/)
+    end
   end
+
+  describe "#idonethis_email" do
+    subject { configuration.idonethis_email }
+
+    context "team account" do
+      let(:account_type) { 'team' }
+      let(:team) { 'foobar' }
+      it { should eq 'foobar@team.idonethis.com' }
+    end
+
+    context "personal account" do
+      let(:account_type) { 'personal' }
+      it { should eq 'today@idonethis.com' }
+    end
+  end
+
+  describe "#personal_account?" do
+    subject { configuration.personal_account? }
+
+    let(:account_type) { 'personal' }
+    it { should be_true }
+  end
+
+  describe "#team_account?" do
+    subject { configuration.team_account? }
+
+    let(:account_type) { 'team' }
+    it { should be_true }
+  end
+
 end

--- a/spec/idid/delivery_spec.rb
+++ b/spec/idid/delivery_spec.rb
@@ -7,9 +7,10 @@ describe Idid::Delivery do
   let(:delivery) { Idid::Delivery.new config }
   let(:config) do
     Idid::Configuration.new(
-      'project' => 'foo',
+      'team' => 'foo',
       'email' => 'john@example.com',
-      'delivery' => { 'method' => :test }
+      'delivery' => { 'method' => :test },
+      'account_type' => 'team'
     )
   end
 


### PR DESCRIPTION
Fixes #5 

I've added basic support for a personal iDoneThis account. No account type switching, yet. I've also renamed `project` to `team` everwhere in the code, as this is more consistent with IDoneThis' own naming conventions.

In order to use this, you need to update your config with a new setting `account_type`. Set this to either `personal` or `team`. If you set it to `personal`, you can leave `team` empty (it will be ignored anyway). You'll also need to rename the old `project` setting to `team`.
